### PR TITLE
Rename publication artifact from 'min' to 'dist'

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ To qualify for the DANDI Compute AIND ephys pipeline, an asset must meet the fol
 
 ## One-time use
 
-If you only plan to use this cache infrequently or from disparate locations, you can directly download the latest version of the cache as a minified and compressed JSON file:
+If you only plan to use this cache infrequently or from disparate locations, you can directly download the latest version of the cache as a compressed JSON file:
 
 ### Python API (recommended)
 
@@ -30,7 +30,7 @@ import json
 
 import requests
 
-url = "https://raw.githubusercontent.com/dandi-cache/qualifying-aind-content-ids/refs/heads/min/derivatives/qualifying_aind_content_ids.min.json.gz"
+url = "https://raw.githubusercontent.com/dandi-cache/qualifying-aind-content-ids/refs/heads/dist/derivatives/qualifying_aind_content_ids.dist.json.gz"
 response = requests.get(url)
 qualifying_aind_content_ids = json.loads(gzip.decompress(data=response.content))
 ```
@@ -38,7 +38,7 @@ qualifying_aind_content_ids = json.loads(gzip.decompress(data=response.content))
 ### Save to file
 
 ```bash
-curl https://raw.githubusercontent.com/dandi-cache/qualifying-aind-content-ids/refs/heads/min/derivatives/qualifying_aind_content_ids.min.json.gz -o qualifying_aind_content_ids.min.json.gz
+curl https://raw.githubusercontent.com/dandi-cache/qualifying-aind-content-ids/refs/heads/dist/derivatives/qualifying_aind_content_ids.dist.json.gz -o qualifying_aind_content_ids.dist.json.gz
 ```
 
 
@@ -48,7 +48,7 @@ curl https://raw.githubusercontent.com/dandi-cache/qualifying-aind-content-ids/r
 If you plan on using this cache regularly, clone this repository:
 
 ```bash
-git clone --branch min --single-branch https://github.com/dandi-cache/qualifying-aind-content-ids.git
+git clone --branch dist --single-branch https://github.com/dandi-cache/qualifying-aind-content-ids.git
 ```
 
 Then set up a CRON on your system to pull the latest version of the cache at your desired frequency.
@@ -70,7 +70,7 @@ Results are kept on dedicated branches so that `main` only ever tracks code:
 - **`derivatives`**: persistent [DataLad](https://www.datalad.org/) dataset holding the full results (`derivatives/`, `logs/`) and the `content-id-to-nwb-files` input as a subdataset.
 Each update is recorded with `datalad run`, so every commit carries the command, the exact input commit, and the output diff as reproducible provenance.
 History is retained.
-- **`min`**: the consumer-facing publication artifact: the minified, compressed JSON (`derivatives/*.min.json.gz`). It is force-recreated on every update.
+- **`dist`**: the consumer-facing publication artifact: the compressed JSON (`derivatives/*.dist.json.gz`). It is force-recreated on every update.
 
 The project's dependencies (declared in `envs/pyproject.toml`) are published as a container image that provides the runtime environment, which is the official way to run the pipeline. The image holds only the environment, not the code: the code is supplied at run time (checked out or mounted), so a single image serves any revision. The image *is* the project's pinned, reproducible environment: the loose dependencies are resolved fresh at build time, so the image (by digest) is the lock and the repository itself keeps no lockfile to hold in sync. It layers this environment on a [NeuroDebian](https://neuro.debian.net/) `trixie` base (which provides Python 3.13 and the recent `git-annex` that [DataLad](https://www.datalad.org/) relies on) and is built and pushed to `ghcr.io/dandi-cache/qualifying-aind-content-ids:latest` by the `Build and Upload Container` workflow on every change to `envs/pyproject.toml` or `containers/`.
 

--- a/code/minify.py
+++ b/code/minify.py
@@ -9,7 +9,7 @@ def _minify(file_path: pathlib.Path, /) -> None:
     with file_path.open(mode="r") as file_stream:
         file_content = [json.loads(line) for line in file_stream if line.strip()]
 
-    minified_file_path = file_path.parent / f"{file_path.stem}.min.json.gz"
+    minified_file_path = file_path.parent / f"{file_path.stem}.dist.json.gz"
     with gzip.open(filename=minified_file_path, mode="wt", encoding="utf-8") as file_stream:
         json.dump(obj=file_content, fp=file_stream)
 

--- a/code/update_pipeline.sh
+++ b/code/update_pipeline.sh
@@ -9,7 +9,7 @@
 #                   `datalad containers-run`, so every update carries full provenance (the
 #                   command, the input subdataset commit, the output diff, and the container
 #                   image digest) and history is retained.
-#   - `min`         is the lightweight, force-recreated publication artifact consumed by
+#   - `dist`        is the lightweight, force-recreated publication artifact consumed by
 #                   downstream users (see README.md).
 #
 # The published image is used purely as the runtime environment: the code and the dataset
@@ -40,7 +40,7 @@ BOT_EMAIL="github-actions[bot]@users.noreply.github.com"
 SUBDATASET_PATH="sourcedata/content-id-to-nwb-files"
 SUBDATASET_URL="https://github.com/dandi-cache/content-id-to-nwb-files.git"
 DS="${RUNNER_TEMP:-/tmp}/derivatives-dataset"
-MINDIR="${RUNNER_TEMP:-/tmp}/min-publish"
+DISTDIR="${RUNNER_TEMP:-/tmp}/dist-publish"
 
 # datalad (with the container extension) from the project environment.
 datalad() { uv run --project "${WORKSPACE}/envs" datalad "$@"; }
@@ -51,7 +51,7 @@ git config --global user.email "${BOT_EMAIL}"
 # The `derivatives` dataset is a standalone clone (not a git worktree): datalad writes the
 # input subdataset's config into `.git/config`, which is a file -- not a directory -- in a
 # worktree, so subdataset registration fails there.
-rm -rf "${DS}" "${MINDIR}"
+rm -rf "${DS}" "${DISTDIR}"
 
 # Reuse the persistent `derivatives` dataset branch, or bootstrap a new one.
 if git ls-remote --heads "${REPO_URL}" derivatives | grep -q refs/heads/derivatives; then
@@ -100,13 +100,13 @@ datalad containers-run -n pipeline --explicit \
 # Publish the full results to the `derivatives` branch.
 git -C "${DS}" push "${REPO_URL}" HEAD:derivatives
 
-# Build and force-publish the consumer-facing minified `min` artifact from a fresh repo.
+# Build and force-publish the consumer-facing `dist` artifact from a fresh repo.
 uv run --project "${WORKSPACE}/envs" python "${WORKSPACE}/code/minify.py" --base-directory "${DS}"
-mkdir -p "${MINDIR}/derivatives"
-cp "${DS}/derivatives/qualifying_aind_content_ids.min.json.gz" "${MINDIR}/derivatives/"
-git -C "${MINDIR}" init -q -b min
-git -C "${MINDIR}" config user.name "${BOT_NAME}"
-git -C "${MINDIR}" config user.email "${BOT_EMAIL}"
-git -C "${MINDIR}" add derivatives
-git -C "${MINDIR}" commit -q -m "Publish minified qualifying AIND content IDs"
-git -C "${MINDIR}" push -f "${REPO_URL}" min:min
+mkdir -p "${DISTDIR}/derivatives"
+cp "${DS}/derivatives/qualifying_aind_content_ids.dist.json.gz" "${DISTDIR}/derivatives/"
+git -C "${DISTDIR}" init -q -b dist
+git -C "${DISTDIR}" config user.name "${BOT_NAME}"
+git -C "${DISTDIR}" config user.email "${BOT_EMAIL}"
+git -C "${DISTDIR}" add derivatives
+git -C "${DISTDIR}" commit -q -m "Publish qualifying AIND content IDs"
+git -C "${DISTDIR}" push -f "${REPO_URL}" dist:dist


### PR DESCRIPTION
## Summary
This PR renames the consumer-facing publication artifact from `min` (minified) to `dist` (distribution) throughout the codebase, including branch names, file extensions, directory names, and documentation.

## Key Changes
- Renamed git branch from `min` to `dist` for publishing consumer-facing artifacts
- Updated directory variable from `MINDIR` to `DISTDIR` in the update pipeline
- Changed output file extension from `.min.json.gz` to `.dist.json.gz`
- Updated all references in documentation (README.md) to reflect the new naming convention
- Updated Python script (`minify.py`) to generate files with `.dist.json.gz` extension
- Updated git clone and download instructions to use the `dist` branch
- Simplified documentation language by removing "minified" descriptor (the file is still compressed, just no longer explicitly called "minified")

## Implementation Details
- All occurrences of the old naming scheme have been consistently replaced across shell scripts, Python code, and documentation
- The functional behavior remains unchanged; this is purely a naming/branding update
- The compressed JSON artifact is still generated the same way, just with updated naming

https://claude.ai/code/session_01PgsgdAsxpL16AVdxW3Epu5