### PR TITLE
Update minified file naming convention from .dist.json.gz to .jsonl.gz

### DIFF
--- a/code/minify.py
+++ b/code/minify.py
@@ -9,7 +9,7 @@ def _minify(file_path: pathlib.Path, /) -> None:
     with file_path.open(mode="r") as file_stream:
         file_content = [json.loads(line) for line in file_stream if line.strip()]
 
-    minified_file_path = file_path.parent / f"{file_path.stem}.dist.json.gz"
+    minified_file_path = file_path.parent / f"{file_path.name}.gz"
     with gzip.open(filename=minified_file_path, mode="wt", encoding="utf-8") as file_stream:
         json.dump(obj=file_content, fp=file_stream)
 

--- a/code/update_pipeline.sh
+++ b/code/update_pipeline.sh
@@ -103,7 +103,7 @@ git -C "${DS}" push "${REPO_URL}" HEAD:derivatives
 # Build and force-publish the consumer-facing `dist` artifact from a fresh repo.
 uv run --project "${WORKSPACE}/envs" python "${WORKSPACE}/code/minify.py" --base-directory "${DS}"
 mkdir -p "${DISTDIR}/derivatives"
-cp "${DS}/derivatives/qualifying_aind_content_ids.dist.json.gz" "${DISTDIR}/derivatives/"
+cp "${DS}/derivatives/qualifying_aind_content_ids.jsonl.gz" "${DISTDIR}/derivatives/"
 git -C "${DISTDIR}" init -q -b dist
 git -C "${DISTDIR}" config user.name "${BOT_NAME}"
 git -C "${DISTDIR}" config user.email "${BOT_EMAIL}"


### PR DESCRIPTION
## Summary
This PR updates the file naming convention for minified JSON output files from `.dist.json.gz` to `.jsonl.gz` to better reflect the actual file format and content structure.

## Key Changes
- **minify.py**: Changed the output filename pattern from `{file_path.stem}.dist.json.gz` to `{file_path.name}.gz`
  - This simplifies the naming logic and preserves the original filename extension (`.jsonl`) before adding the gzip compression extension
- **update_pipeline.sh**: Updated the file copy operation to reference the new filename `qualifying_aind_content_ids.jsonl.gz` instead of `qualifying_aind_content_ids.dist.json.gz`

## Implementation Details
The change in `minify.py` uses `file_path.name` instead of `file_path.stem`, which preserves the full original filename (including its extension) rather than stripping it. This means a file named `qualifying_aind_content_ids.jsonl` will now produce `qualifying_aind_content_ids.jsonl.gz` instead of `qualifying_aind_content_ids.dist.json.gz`, making the file format more transparent and consistent with the actual JSONL content format.

https://claude.ai/code/session_012D3UgJJbiF1LASn9gnrbpB