### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build_and_upload_docker_image.yml
+++ b/.github/workflows/build_and_upload_docker_image.yml
@@ -1,5 +1,9 @@
 name: Build and Upload Container
 
+permissions:
+  contents: read
+  packages: read
+
 on:
   push:
     branches: [ main ]

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -71,9 +71,6 @@ jobs:
         run: bash code/update_pipeline.sh
 
   NotifyOnFailure:
-    permissions:
-      contents: read
-      packages: read
     runs-on: ubuntu-latest
     needs: [ Update ]
     if: ${{ always() && failure() }}

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -1,5 +1,9 @@
 name: Update
 
+permissions:
+  contents: read
+  packages: read
+
 on:
   schedule:
     - cron: "0 6/4 * * *"
@@ -20,6 +24,10 @@ env:
 
 jobs:
   Update:
+    permissions:
+      actions: write
+      contents: read
+      packages: read
     runs-on: ubuntu-latest
 
     steps:
@@ -63,6 +71,9 @@ jobs:
         run: bash code/update_pipeline.sh
 
   NotifyOnFailure:
+    permissions:
+      contents: read
+      packages: read
     runs-on: ubuntu-latest
     needs: [ Update ]
     if: ${{ always() && failure() }}


### PR DESCRIPTION
Potential fix for [https://github.com/dandi-cache/qualifying-aind-content-ids/security/code-scanning/3](https://github.com/dandi-cache/qualifying-aind-content-ids/security/code-scanning/3)

Add explicit `permissions` blocks so token scope is documented and restricted.

Best single fix without changing behavior:
- Add a workflow-level `permissions` block with minimal baseline:
  - `contents: read`
  - `packages: read`
- Add job-level override for `Update` because it cancels workflow runs via `gh run cancel`, which requires Actions write permission:
  - `actions: write`
  - keep `contents: read`, `packages: read` for clarity
- Add job-level permissions for `NotifyOnFailure` as read-only baseline:
  - `contents: read`
  - `packages: read`

Edit only `.github/workflows/update.yml` in:
- after `name:` / before `on:` for root permissions
- under `jobs.Update` and `jobs.NotifyOnFailure` before `runs-on`

No imports/dependencies/methods are needed (YAML-only change).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
