### PR TITLE
Update submodule references from content-id-to-nwb-files to content-id-to-usage-dandiset-path

### DIFF
--- a/code/update.py
+++ b/code/update.py
@@ -64,8 +64,8 @@ def _load_ids(file_path: pathlib.Path) -> set:
 
 
 def _run(base_directory: pathlib.Path, limit: int | None) -> None:
-    submodule_dir = base_directory / "sourcedata" / "content-id-to-nwb-files" / "derivatives"
-    submodule_file_path = submodule_dir / "content_id_to_nwb_files.yaml"
+    submodule_dir = base_directory / "sourcedata" / "content-id-to-usage-dandiset-path" / "derivatives"
+    submodule_file_path = submodule_dir / "content_id_to_usage_dandiset_path.yaml"
     with submodule_file_path.open(mode="r") as file_stream:
         content_id_to_dandiset_paths = yaml.safe_load(file_stream)
 

--- a/code/update_pipeline.sh
+++ b/code/update_pipeline.sh
@@ -37,8 +37,8 @@ GITHUB_SHA="${GITHUB_SHA:-unknown}"
 
 BOT_NAME="github-actions[bot]"
 BOT_EMAIL="github-actions[bot]@users.noreply.github.com"
-SUBDATASET_PATH="sourcedata/content-id-to-nwb-files"
-SUBDATASET_URL="https://github.com/dandi-cache/content-id-to-nwb-files.git"
+SUBDATASET_PATH="sourcedata/content-id-to-usage-dandiset-path"
+SUBDATASET_URL="https://github.com/dandi-cache/content-id-to-usage-dandiset-path.git"
 DS="${RUNNER_TEMP:-/tmp}/derivatives-dataset"
 DISTDIR="${RUNNER_TEMP:-/tmp}/dist-publish"
 


### PR DESCRIPTION
## Summary
This PR updates references to the content-id mapping submodule to reflect a rename from `content-id-to-nwb-files` to `content-id-to-usage-dandiset-path`, along with corresponding updates to file and variable names.

## Key Changes
- Updated submodule directory path in `update.py` from `content-id-to-nwb-files` to `content-id-to-usage-dandiset-path`
- Renamed YAML file reference from `content_id_to_nwb_files.yaml` to `content_id_to_usage_dandiset_path.yaml`
- Updated `SUBDATASET_PATH` in `update_pipeline.sh` to point to the new submodule directory
- Updated `SUBDATASET_URL` in `update_pipeline.sh` to reference the renamed GitHub repository

## Implementation Details
These changes ensure that the update pipeline correctly references the renamed submodule and its associated data files. The variable names and paths have been updated consistently across both the Python script and the shell script to maintain alignment with the new naming convention.

https://claude.ai/code/session_01Cbdwr1zu5DuCmVYp5Mzxja