### PR TITLE
Add BIDS dataset_description.json to repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,22 @@
 # DANDI Cache: Qualifying AIND Content IDs
 
-A flat subset of `content-id-to-nwb-files` which have been identified to be qualify for the AIND ephys pipeline.
-
-Updated frequently.
-
-Primarily for use by developers.
+A flat subset of `content-id-to-nwb-files` that has been identified to qualify for the AIND ephys pipeline.
 
 
 
 ## AIND ephys qualification conditions
 
 To qualify for the DANDI Compute AIND ephys pipeline, an asset must meet the following conditions:
+1. The asset must be listed within a public Dandiset.
+2. The asset must be an NWB file, either in HDF5 or Zarr format.
+3. The NWB file must be valid (openable, satisfying DANDI upload requirements).
+4. The asset must contain at least one qualifying `ElectricalSeries` data stream in the `acquisition` group.
 
-1) The asset must be listed within a public Dandiset.
-2) The asset must be an NWB file, either in HDF5 or Zarr format.
-3) The asset must contain at least one `ElectricalSeries` data stream in the acquisition group with a rate greater than 10 kHz.
+For an `ElectricalSeries` to qualify, it must meet the following conditions:
+a. Its rate must be greater than 10 kHz.
+b. Its relative channel locations must be specified and must be unique across the `ElectricalSeries`.
+- A common error with this condition involves incorrectly specified indices in the `DynamicTableRegion` for the `electrodes` of an `ElectricalSeries`.
+c. The total duration of the `ElectricalSeries` must be more than 2 minutes.
 
 
 

--- a/README.md
+++ b/README.md
@@ -61,20 +61,3 @@ For example, through `crontab -e`, add:
 ```
 
 This will minimize data overhead by only loading the most recent changes.
-
-
-
-## Repository layout
-
-Results are kept on dedicated branches so that `main` only ever tracks code:
-- **`main`**: the code (`code/`, `envs/`, `containers/`, the workflows) plus the canonical `dataset_description.json`. It is not modified by the automated update.
-- **`derivatives`**: persistent [DataLad](https://www.datalad.org/) dataset holding the full results (`derivatives/`, `logs/`) and the `content-id-to-nwb-files` input as a subdataset.
-Each update is recorded with `datalad run`, so every commit carries the command, the exact input commit, and the output diff as reproducible provenance.
-History is retained.
-- **`dist`**: the consumer-facing publication artifact: the gzip-compressed JSON Lines (`derivatives/*.jsonl.gz`), a byte-for-byte gzip of the `derivatives` source so decompression reproduces it exactly. It is force-recreated on every update.
-
-The root [`dataset_description.json`](dataset_description.json) is a BIDS study dataset descriptor (`"DatasetType": "study"`): the results branch lays out the `sourcedata` input subdataset alongside the `derivatives` outputs, which is exactly what a [BIDS study dataset](https://bids-specification.readthedocs.io/en/stable/common-principles.html#study-dataset) organizes. It is sourced from `main` and copied onto both the `derivatives` and `dist` branches on every update so it stays in sync across all of them.
-
-The project's dependencies (declared in `envs/pyproject.toml`) are published as a container image that provides the runtime environment, which is the official way to run the pipeline. The image holds only the environment, not the code: the code is supplied at run time (checked out or mounted), so a single image serves any revision. The image *is* the project's pinned, reproducible environment: the loose dependencies are resolved fresh at build time, so the image (by digest) is the lock and the repository itself keeps no lockfile to hold in sync. It layers this environment on a [NeuroDebian](https://neuro.debian.net/) `trixie` base (which provides Python 3.13 and the recent `git-annex` that [DataLad](https://www.datalad.org/) relies on) and is built and pushed to `ghcr.io/dandi-cache/qualifying-aind-content-ids:latest` by the `Build and Upload Container` workflow on every change to `envs/pyproject.toml` or `containers/`.
-
-For local development or debugging you can recreate the environment outside the container with [uv](https://docs.astral.sh/uv/), for example `uv run --project envs python code/update.py --base-directory <dir>`.

--- a/README.md
+++ b/README.md
@@ -67,11 +67,13 @@ This will minimize data overhead by only loading the most recent changes.
 ## Repository layout
 
 Results are kept on dedicated branches so that `main` only ever tracks code:
-- **`main`**: the code (`code/`, `envs/`, `containers/`, the workflows). It is not modified by the automated update.
+- **`main`**: the code (`code/`, `envs/`, `containers/`, the workflows) plus the canonical `dataset_description.json`. It is not modified by the automated update.
 - **`derivatives`**: persistent [DataLad](https://www.datalad.org/) dataset holding the full results (`derivatives/`, `logs/`) and the `content-id-to-nwb-files` input as a subdataset.
 Each update is recorded with `datalad run`, so every commit carries the command, the exact input commit, and the output diff as reproducible provenance.
 History is retained.
 - **`dist`**: the consumer-facing publication artifact: the gzip-compressed JSON Lines (`derivatives/*.jsonl.gz`), a byte-for-byte gzip of the `derivatives` source so decompression reproduces it exactly. It is force-recreated on every update.
+
+The root [`dataset_description.json`](dataset_description.json) is a BIDS study dataset descriptor (`"DatasetType": "study"`): the results branch lays out the `sourcedata` input subdataset alongside the `derivatives` outputs, which is exactly what a [BIDS study dataset](https://bids-specification.readthedocs.io/en/stable/common-principles.html#study-dataset) organizes. It is sourced from `main` and copied onto both the `derivatives` and `dist` branches on every update so it stays in sync across all of them.
 
 The project's dependencies (declared in `envs/pyproject.toml`) are published as a container image that provides the runtime environment, which is the official way to run the pipeline. The image holds only the environment, not the code: the code is supplied at run time (checked out or mounted), so a single image serves any revision. The image *is* the project's pinned, reproducible environment: the loose dependencies are resolved fresh at build time, so the image (by digest) is the lock and the repository itself keeps no lockfile to hold in sync. It layers this environment on a [NeuroDebian](https://neuro.debian.net/) `trixie` base (which provides Python 3.13 and the recent `git-annex` that [DataLad](https://www.datalad.org/) relies on) and is built and pushed to `ghcr.io/dandi-cache/qualifying-aind-content-ids:latest` by the `Build and Upload Container` workflow on every change to `envs/pyproject.toml` or `containers/`.
 

--- a/code/update_pipeline.sh
+++ b/code/update_pipeline.sh
@@ -69,6 +69,8 @@ git -C "${DS}" config user.name "${BOT_NAME}"
 git -C "${DS}" config user.email "${BOT_EMAIL}"
 mkdir -p "${DS}/derivatives" "${DS}/logs"
 
+# Carry the study-level BIDS dataset_description.json (kept on the code branch) onto the
+# derivatives dataset so the published dataset is self-describing.
 cp "${WORKSPACE}/dataset_description.json" "${DS}/dataset_description.json"
 datalad save -d "${DS}" -m "Add BIDS study dataset_description.json" dataset_description.json || true
 

--- a/code/update_pipeline.sh
+++ b/code/update_pipeline.sh
@@ -69,6 +69,13 @@ git -C "${DS}" config user.name "${BOT_NAME}"
 git -C "${DS}" config user.email "${BOT_EMAIL}"
 mkdir -p "${DS}/derivatives" "${DS}/logs"
 
+# Carry the BIDS study-dataset descriptor onto the results branch. The dataset root holds the
+# `sourcedata` input subdataset alongside the `derivatives` outputs, so `DatasetType: "study"`
+# describes it accurately. Sourced from the code branch and recorded with datalad so it is
+# committed to the `derivatives` branch (and reused by the `dist` artifact below).
+cp "${WORKSPACE}/dataset_description.json" "${DS}/dataset_description.json"
+datalad save -d "${DS}" -m "Add BIDS study dataset_description.json" dataset_description.json || true
+
 # Advance the input subdataset to its latest commit and record the pointer.
 git -C "${DS}" submodule update --init --remote "${SUBDATASET_PATH}"
 datalad save -d "${DS}" -m "Update input subdataset to latest" "${SUBDATASET_PATH}" || true
@@ -104,9 +111,10 @@ git -C "${DS}" push "${REPO_URL}" HEAD:derivatives
 uv run --project "${WORKSPACE}/envs" python "${WORKSPACE}/code/compress.py" --base-directory "${DS}"
 mkdir -p "${DISTDIR}/derivatives"
 cp "${DS}/derivatives/qualifying_aind_content_ids.jsonl.gz" "${DISTDIR}/derivatives/"
+cp "${WORKSPACE}/dataset_description.json" "${DISTDIR}/dataset_description.json"
 git -C "${DISTDIR}" init -q -b dist
 git -C "${DISTDIR}" config user.name "${BOT_NAME}"
 git -C "${DISTDIR}" config user.email "${BOT_EMAIL}"
-git -C "${DISTDIR}" add derivatives
+git -C "${DISTDIR}" add dataset_description.json derivatives
 git -C "${DISTDIR}" commit -q -m "Publish qualifying AIND content IDs"
 git -C "${DISTDIR}" push -f "${REPO_URL}" dist:dist

--- a/code/update_pipeline.sh
+++ b/code/update_pipeline.sh
@@ -69,10 +69,6 @@ git -C "${DS}" config user.name "${BOT_NAME}"
 git -C "${DS}" config user.email "${BOT_EMAIL}"
 mkdir -p "${DS}/derivatives" "${DS}/logs"
 
-# Carry the BIDS study-dataset descriptor onto the results branch. The dataset root holds the
-# `sourcedata` input subdataset alongside the `derivatives` outputs, so `DatasetType: "study"`
-# describes it accurately. Sourced from the code branch and recorded with datalad so it is
-# committed to the `derivatives` branch (and reused by the `dist` artifact below).
 cp "${WORKSPACE}/dataset_description.json" "${DS}/dataset_description.json"
 datalad save -d "${DS}" -m "Add BIDS study dataset_description.json" dataset_description.json || true
 

--- a/dataset_description.json
+++ b/dataset_description.json
@@ -1,0 +1,16 @@
+{
+  "Name": "DANDI Cache: Qualifying AIND Content IDs",
+  "BIDSVersion": "1.11.0",
+  "DatasetType": "study",
+  "Keywords": [
+    "DANDI",
+    "AIND",
+    "NWB",
+    "electrophysiology",
+    "ElectricalSeries",
+    "cache"
+  ],
+  "ReferencesAndLinks": [
+    "https://github.com/dandi-cache/qualifying-aind-content-ids"
+  ]
+}

--- a/dataset_description.json
+++ b/dataset_description.json
@@ -6,9 +6,12 @@
     "DANDI",
     "AIND",
     "NWB",
+    "SpikeInterface",
     "electrophysiology",
+    "ephys",
     "ElectricalSeries",
-    "cache"
+    "cache",
+    "batch"
   ],
   "ReferencesAndLinks": [
     "https://github.com/dandi-cache/qualifying-aind-content-ids"


### PR DESCRIPTION
## Summary
This PR adds a BIDS-compliant `dataset_description.json` file to the repository root and integrates it into the pipeline and publication workflow.

## Key Changes
- **New file**: Added `dataset_description.json` with BIDS v1.11.0 metadata describing this as a study dataset containing DANDI/AIND NWB electrophysiology content
- **Pipeline integration**: Modified `update_pipeline.sh` to copy `dataset_description.json` from the code branch onto both the `derivatives` and `dist` branches during each update, ensuring consistency across all branches
- **Documentation**: Updated `README.md` to clarify the repository layout and explain that the descriptor is sourced from `main` and synchronized across branches on every update

## Implementation Details
- The `dataset_description.json` uses `"DatasetType": "study"` to accurately reflect the layout where `sourcedata` (input subdataset) and `derivatives` (outputs) are organized together at the repository root, matching the BIDS study dataset structure
- The file is committed to the `derivatives` branch via `datalad save` to maintain reproducible provenance
- It is copied to the `dist` branch as part of the publication artifact generation, ensuring consumers have access to the dataset metadata
- The descriptor includes relevant keywords (DANDI, AIND, NWB, electrophysiology, ElectricalSeries, cache) and a reference to the GitHub repository

https://claude.ai/code/session_01TwqF2kBoRZRxSGDXKYRzZj