### PR TITLE
Add OCI labels to Docker image for GitHub Container Registry

### DIFF
--- a/containers/Dockerfile
+++ b/containers/Dockerfile
@@ -15,6 +15,11 @@
 # and its provenance.
 FROM neurodebian:trixie
 
+# The `source` label is what GitHub Container Registry uses to associate the published
+# image with this repository.
+LABEL org.opencontainers.image.source="https://github.com/dandi-cache/qualifying-aind-content-ids"
+LABEL org.opencontainers.image.description="Pinned runtime environment for qualifying AIND ephys content IDs on the DANDI Cache."
+
 # git-annex (for DataLad / annex provenance), Python, and the basics for cloning and TLS.
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
## Summary
Added Open Container Initiative (OCI) image labels to the Dockerfile to enable proper association with the GitHub repository and provide image metadata.

## Key Changes
- Added `org.opencontainers.image.source` label pointing to the GitHub repository
- Added `org.opencontainers.image.description` label with a descriptive summary of the image's purpose

## Details
These labels follow the OCI Image Spec standard and are specifically used by GitHub Container Registry to link published container images back to their source repository. This improves discoverability and provides users with clear information about the image's purpose when viewing it in the registry.

https://claude.ai/code/session_014DJU4Vukzy2xFJFgagy3fc