### PR TITLE
Replace YAML with JSONL format for content ID mapping

### DIFF
--- a/code/update.py
+++ b/code/update.py
@@ -11,7 +11,6 @@ import nwbinspector
 import pynwb
 import remfile
 import spikeinterface.extractors
-import yaml
 
 
 def _nwb_file_qualifies(s3_url: str) -> bool:
@@ -93,9 +92,12 @@ def _log_error(log_file_path: pathlib.Path, message: str) -> None:
 
 def _run(base_directory: pathlib.Path, limit: int | None) -> None:
     submodule_dir = base_directory / "sourcedata" / "content-id-to-usage-dandiset-path" / "derivatives"
-    submodule_file_path = submodule_dir / "content_id_to_usage_dandiset_path.yaml"
+    submodule_file_path = submodule_dir / "content_id_to_usage_dandiset_path.jsonl"
+    content_id_to_dandiset_path = {}
     with submodule_file_path.open(mode="r") as file_stream:
-        content_id_to_dandiset_path = yaml.safe_load(file_stream)
+        for line in file_stream:
+            if line.strip():
+                content_id_to_dandiset_path.update(json.loads(line))
 
     logs_dir = base_directory / "logs"
     logs_dir.mkdir(parents=True, exist_ok=True)

--- a/envs/pyproject.toml
+++ b/envs/pyproject.toml
@@ -3,7 +3,6 @@ name = "qualifying-aind-content-ids"
 version = "0.1.0"
 requires-python = ">=3.13"
 dependencies = [
-    "pyyaml",
     "remfile",
     "h5py",
     "zarr",


### PR DESCRIPTION
## Summary
This PR migrates the content ID to dandiset path mapping from YAML to JSONL (JSON Lines) format, removing the dependency on PyYAML.

## Key Changes
- Changed the input file format from `content_id_to_usage_dandiset_path.yaml` to `content_id_to_usage_dandiset_path.jsonl`
- Replaced `yaml.safe_load()` with line-by-line JSON parsing to read the JSONL file
- Removed the `pyyaml` dependency from `pyproject.toml`
- Removed the `import yaml` statement from `update.py`

## Implementation Details
- The new JSONL parsing iterates through each line in the file, skips empty lines, and merges each JSON object into the `content_id_to_dandiset_path` dictionary
- This approach maintains the same functionality while using only the standard library `json` module (already imported in the file)

https://claude.ai/code/session_019ENnk2e1Ptwc93AfzsRyrp