### PR TITLE
Add DataLad clone instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,12 @@ If you plan on using this cache regularly, clone this repository:
 git clone --branch dist --single-branch https://github.com/dandi-cache/qualifying-aind-content-ids.git
 ```
 
+Or, if you prefer [DataLad](https://www.datalad.org/):
+
+```bash
+datalad clone https://github.com/dandi-cache/qualifying-aind-content-ids.git --branch derivatives
+```
+
 Then set up a CRON on your system to pull the latest version of the cache at your desired frequency.
 
 For example, through `crontab -e`, add:


### PR DESCRIPTION
## Summary
Added alternative installation instructions using DataLad as an option for cloning the cache repository.

## Changes
- Added a new section in the README documenting how to clone the repository using DataLad
- Included example command: `datalad clone https://github.com/dandi-cache/qualifying-aind-content-ids.git --branch derivatives`
- Positioned the new instructions after the existing git clone method to provide users with an alternative approach

## Details
This change provides users who prefer DataLad with a documented way to obtain the cache. The DataLad clone command uses the `derivatives` branch, which may be the appropriate branch for DataLad-based workflows in this project.

https://claude.ai/code/session_01GhJziMGgPn3wNLuvbGofDT