### PR TITLE
Fix subdataset initialization to track derivatives branch

### DIFF
--- a/code/update_pipeline.sh
+++ b/code/update_pipeline.sh
@@ -57,7 +57,6 @@ rm -rf "${DS}" "${DISTDIR}"
 if git ls-remote --heads "${REPO_URL}" derivatives | grep -q refs/heads/derivatives; then
   echo "Reusing the existing 'derivatives' dataset branch."
   git clone --branch derivatives --single-branch "${REPO_URL}" "${DS}"
-  git -C "${DS}" submodule update --init "${SUBDATASET_PATH}"
 else
   echo "Bootstrapping a new 'derivatives' DataLad dataset."
   datalad create --no-annex "${DS}"
@@ -74,9 +73,14 @@ mkdir -p "${DS}/derivatives" "${DS}/logs"
 cp "${WORKSPACE}/dataset_description.json" "${DS}/dataset_description.json"
 datalad save -d "${DS}" -m "Add BIDS study dataset_description.json" dataset_description.json || true
 
-# Advance the input subdataset to its latest commit and record the pointer.
+# Advance the input subdataset to the tip of upstream's `derivatives` branch (where the
+# input data is published) and record the pointer. The tracking branch is explicit, and the
+# submodule is only ever initialized with `--remote` so the previously recorded commit is
+# never fetched: upstream rewrites its history, so that commit may no longer exist on the
+# remote and fetching it fails with "not our ref".
+git -C "${DS}" submodule set-branch --branch derivatives -- "${SUBDATASET_PATH}"
 git -C "${DS}" submodule update --init --remote "${SUBDATASET_PATH}"
-datalad save -d "${DS}" -m "Update input subdataset to latest" "${SUBDATASET_PATH}" || true
+datalad save -d "${DS}" -m "Update input subdataset to latest" "${SUBDATASET_PATH}" .gitmodules || true
 
 cd "${DS}"
 


### PR DESCRIPTION
## Summary
Updated the pipeline to properly track the `derivatives` branch when initializing the input subdataset, and adjusted the submodule update strategy to always fetch from the remote tip rather than a potentially stale cached commit.

## Key Changes
- Removed premature submodule initialization that occurred immediately after cloning the derivatives branch
- Added explicit branch tracking configuration via `git submodule set-branch --branch derivatives` to ensure the subdataset follows the upstream `derivatives` branch
- Changed submodule update to always use `--remote` flag, which fetches the latest commit from the tracked branch instead of a previously recorded commit
- Updated the datalad save command to also commit `.gitmodules` changes alongside the subdataset pointer update
- Enhanced comments to explain the rationale: upstream rewrites history, so previously recorded commits may no longer exist on the remote

## Implementation Details
The key insight is that by using `--remote` with submodule update, the pipeline now always points to the tip of the upstream `derivatives` branch rather than a specific commit that may have been rewritten or deleted. This is necessary because the upstream repository rewrites its history, making old commit references invalid. The explicit branch tracking via `set-branch` ensures this behavior is maintained across future updates.

https://claude.ai/code/session_01SJKEa675ibSL93TJwfEeyy