### PR TITLE
Implement log file size management to prevent GitHub blob limits

### DIFF
--- a/code/update.py
+++ b/code/update.py
@@ -84,10 +84,36 @@ def _is_nwb_file(path: str) -> bool:
     return suffixes[-2:] == [".nwb", ".zarr"] or suffixes[-1:] == [".nwb"]
 
 
+# The `derivatives` dataset is a persistent DataLad dataset: these logs accumulate across every
+# run forever (entries are never otherwise removed), and GitHub hard-rejects any single blob over
+# 100 MB. Keep each log file comfortably under that limit by dropping the oldest entries once it
+# grows past this cap.
+_MAX_LOG_FILE_SIZE_BYTES = 80_000_000
+
+
 def _log_error(log_file_path: pathlib.Path, message: str) -> None:
-    """Append a single error report to the given error log, separated by a blank line."""
+    """Append a single error report to the given error log, separated by a blank line.
+
+    If the file has grown past `_MAX_LOG_FILE_SIZE_BYTES`, the oldest entries are dropped first so
+    the file never approaches GitHub's 100 MB per-file limit.
+    """
     with log_file_path.open(mode="a") as file_stream:
         file_stream.write(f"{message}\n\n")
+
+    if log_file_path.stat().st_size <= _MAX_LOG_FILE_SIZE_BYTES:
+        return
+
+    with log_file_path.open(mode="rb") as file_stream:
+        file_stream.seek(-_MAX_LOG_FILE_SIZE_BYTES, 2)
+        tail = file_stream.read()
+
+    # Realign to the start of the next whole entry so no partial entry is kept.
+    next_entry_offset = tail.find(b"\n\n")
+    if next_entry_offset != -1:
+        tail = tail[next_entry_offset + 2 :]
+
+    with log_file_path.open(mode="wb") as file_stream:
+        file_stream.write(tail)
 
 
 def _run(base_directory: pathlib.Path, limit: int | None) -> None:


### PR DESCRIPTION
## Summary
Added automatic log file size management to the error logging function to prevent log files from exceeding GitHub's 100 MB per-file limit in the persistent DataLad derivatives dataset.

## Key Changes
- Added `_MAX_LOG_FILE_SIZE_BYTES` constant set to 80 MB as a safety threshold
- Enhanced `_log_error()` function to monitor and trim log files when they exceed the size limit
- Implemented intelligent trimming that removes oldest entries while preserving entry integrity by realigning to entry boundaries (marked by `\n\n` separators)
- Updated docstring to document the new size management behavior

## Implementation Details
The trimming logic:
1. Appends the new error message first
2. Checks if file size exceeds the limit
3. If exceeded, seeks to the last 80 MB of the file and reads that tail
4. Finds the next complete entry boundary (`\n\n`) to avoid keeping partial entries
5. Rewrites the file with only the trimmed tail, effectively dropping the oldest entries

This approach ensures log files stay well below GitHub's hard limit while maintaining complete error entries.

https://claude.ai/code/session_01HXRvZCr3CqxMm3WKVHPycT