### PR TITLE
Add NaN channel location validation to NWB file qualification

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,9 @@ Each acquisition `ElectricalSeries` above 10 kHz must therefore meet the followi
 
 a. Its total duration must be more than 2 minutes.
 
-b. It must survive the pipeline's split-then-aggregate step. When a series spans more than one channel group, the pipeline splits it by group (as `aind-ephys-job-dispatch` does) and recombines the groups with `spikeinterface.aggregate_channels` (as `aind-ecephys-nwb` does); this requires the relative channel locations to remain unique once the groups are combined. The qualification check mimics this exactly by performing the same split-and-aggregate and excluding the asset if it raises.
+b. Its channel locations must not contain `NaN` values.
+
+c. It must survive the pipeline's split-then-aggregate step. When a series spans more than one channel group, the pipeline splits it by group (as `aind-ephys-job-dispatch` does) and recombines the groups with `spikeinterface.aggregate_channels` (as `aind-ecephys-nwb` does); this requires the relative channel locations to remain unique once the groups are combined. The qualification check mimics this exactly by performing the same split-and-aggregate and excluding the asset if it raises.
 - A common error with this condition involves incorrectly specified indices in the `DynamicTableRegion` for the `electrodes` of an `ElectricalSeries`.
 
 

--- a/code/update.py
+++ b/code/update.py
@@ -7,6 +7,7 @@ import traceback
 import dandi.dandiapi
 import h5py
 import hdmf_zarr
+import numpy
 import nwbinspector
 import pynwb
 import remfile
@@ -20,8 +21,9 @@ def _nwb_file_qualifies(s3_url: str) -> bool:
     Only ElectricalSeries in the acquisition submodule with a sampling rate above 10kHz are
     assessed; lower-rate series (e.g. LFP) are ignored. The pipeline processes every such series,
     so a single non-processable one would make it fail: each must have a duration longer than 120
-    seconds and survive the pipeline's split-then-aggregate step. The file qualifies when at least
-    one acquisition ElectricalSeries exceeds 10kHz and every series that does passes those checks.
+    seconds, have no NaN channel locations, and survive the pipeline's split-then-aggregate step.
+    The file qualifies when at least one acquisition ElectricalSeries exceeds 10kHz and every
+    series that does passes those checks.
     """
     electrical_series_paths = spikeinterface.extractors.NwbRecordingExtractor.fetch_available_electrical_series_paths(
         file_path=s3_url, stream_mode="remfile"
@@ -48,6 +50,11 @@ def _nwb_file_qualifies(s3_url: str) -> bool:
         any_above_rate_threshold = True
 
         if extractor.get_total_duration() <= 120:
+            return False
+
+        # A NaN channel location breaks the pipeline's downstream distance/geometry computations
+        # just as surely as the aggregation failure below, so exclude it the same way.
+        if numpy.isnan(extractor.get_channel_locations()).any():
             return False
 
         # Mimic the pipeline as closely as possible. job_dispatch (aind-ephys-job-dispatch) splits


### PR DESCRIPTION
## Summary
This PR adds validation to exclude NWB files with NaN channel locations from processing, as such values break downstream pipeline computations.

## Key Changes
- **Import addition**: Added `numpy` import to support NaN checking
- **Validation logic**: Added a check in `_nwb_file_qualifies()` to detect and reject ElectricalSeries with NaN values in channel locations
- **Documentation updates**: Updated docstring and README to reflect the new NaN channel location requirement as a qualification criterion

## Implementation Details
- The NaN check uses `numpy.isnan().any()` on the channel locations array returned by `extractor.get_channel_locations()`
- This validation is performed after the duration check but before the split-then-aggregate step, following the logical flow of other checks
- The check is positioned to catch issues early, preventing failures in downstream distance/geometry computations
- Updated documentation clarifies that this is now requirement (b) in the qualification criteria, with the split-then-aggregate step moved to (c)

https://claude.ai/code/session_01DpmtoDw9GVTUQUcyHZiMGb