### PR TITLE
Delegate NWB validation to upstream cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ A flat subset of `content-id-to-nwb-files` that has been identified to qualify f
 To qualify for the DANDI Compute AIND ephys pipeline, an asset must meet the following conditions:
 1. The asset must be listed within a public Dandiset.
 2. The asset must be an NWB file, either in HDF5 or Zarr format.
-3. The NWB file must be valid (openable, satisfying DANDI upload requirements).
+3. The NWB file must be valid (openable, satisfying DANDI upload requirements), as determined by the
+   [`content-id-to-valid-nwb-file`](https://github.com/dandi-cache/content-id-to-valid-nwb-file) cache.
 4. The NWB file must contain at least one `ElectricalSeries` data stream in the `acquisition` group with a `rate` greater than 10 kHz.
 
 Only acquisition `ElectricalSeries` with a `rate` greater than 10 kHz are assessed further; lower-rate series (e.g. LFP) are ignored.

--- a/code/update.py
+++ b/code/update.py
@@ -5,12 +5,7 @@ import pathlib
 import traceback
 
 import dandi.dandiapi
-import h5py
-import hdmf_zarr
 import numpy
-import nwbinspector
-import pynwb
-import remfile
 import spikeinterface.extractors
 
 
@@ -132,11 +127,20 @@ def _run(base_directory: pathlib.Path, limit: int | None) -> None:
             if line.strip():
                 content_id_to_dandiset_path.update(json.loads(line))
 
+    # The `content-id-to-valid-nwb-file` cache already confirms each NWB file opens successfully
+    # and passes the NWB Inspector at the CRITICAL threshold, so this pipeline can trust that
+    # result instead of repeating the file-open/inspection work itself.
+    valid_nwb_submodule_dir = base_directory / "sourcedata" / "content-id-to-valid-nwb-file" / "derivatives"
+    valid_nwb_file_path = valid_nwb_submodule_dir / "content_id_to_valid_nwb_file.jsonl"
+    content_id_to_valid_nwb_file = {}
+    with valid_nwb_file_path.open(mode="r") as file_stream:
+        for line in file_stream:
+            if line.strip():
+                content_id_to_valid_nwb_file.update(json.loads(line))
+
     logs_dir = base_directory / "logs"
     logs_dir.mkdir(parents=True, exist_ok=True)
     dandi_api_errors_log_file_path = logs_dir / "dandi_api_errors.txt"
-    file_open_errors_log_file_path = logs_dir / "file_open_errors.txt"
-    nwb_inspector_errors_log_file_path = logs_dir / "nwb_inspector_errors.txt"
     spikeinterface_errors_log_file_path = logs_dir / "spikeinterface_errors.txt"
     unexpected_errors_log_file_path = logs_dir / "unexpected_errors.txt"
 
@@ -144,8 +148,6 @@ def _run(base_directory: pathlib.Path, limit: int | None) -> None:
     # failure before the first labelled stage) falls back to the catch-all `unexpected_errors.txt`.
     stage_to_log_file_path = {
         "retrieving asset information from the DANDI API": dandi_api_errors_log_file_path,
-        "opening the NWB file": file_open_errors_log_file_path,
-        "running the NWB Inspector": nwb_inspector_errors_log_file_path,
         "validating SpikeInterface metadata": spikeinterface_errors_log_file_path,
     }
 
@@ -155,19 +157,27 @@ def _run(base_directory: pathlib.Path, limit: int | None) -> None:
     processed_ids_file_path = base_directory / "derivatives" / "processed_ids.jsonl"
     processed_ids = _load_ids(processed_ids_file_path)
 
-    # Only NWB assets can qualify, so skip everything else (raw imaging, video, ephys bundles, ...)
-    # up front based on the mapped path, before spending any DANDI API or file-open work on them.
+    # Content IDs the upstream cache has already flagged as not a valid NWB file are disqualified
+    # without spending any further work on them; they are not errors, just non-qualifying.
+    processed_ids |= {
+        content_id
+        for content_id in content_id_to_valid_nwb_file.keys() - error_ids - processed_ids
+        if content_id_to_valid_nwb_file[content_id] is False
+    }
+
+    # Only NWB assets that the upstream cache has confirmed are valid can qualify. Assets not yet
+    # present in that cache are left for a future run once upstream has assessed them.
     content_ids_to_process = {
         content_id
         for content_id in content_id_to_dandiset_path.keys() - error_ids - processed_ids
-        if _is_nwb_file(next(iter(content_id_to_dandiset_path[content_id].values())))
+        if content_id_to_valid_nwb_file.get(content_id) is True
+        and _is_nwb_file(next(iter(content_id_to_dandiset_path[content_id].values())))
     }
 
     qualifying_aind_content_ids_file_path = base_directory / "derivatives" / "qualifying_aind_content_ids.jsonl"
     qualifying_aind_content_ids = _load_ids(qualifying_aind_content_ids_file_path)
 
     client = dandi.dandiapi.DandiAPIClient()  # Run tokenless to ensure only public dandisets are accessed
-    dandi_config = nwbinspector.load_config("dandi")
     for content_id in itertools.islice(content_ids_to_process, limit):
         # Defaults so the catch-all handler can report context even if the very first step fails.
         dandiset_id = first_path = s3_url = None
@@ -179,37 +189,6 @@ def _run(base_directory: pathlib.Path, limit: int | None) -> None:
             dandiset = client.get_dandiset(dandiset_id=dandiset_id)
             asset = dandiset.get_asset_by_path(path=first_path)
             s3_url = asset.get_content_url(follow_redirects=1, strip_query=True)
-
-            stage = "opening the NWB file"
-            if ".zarr" in pathlib.Path(first_path).suffixes:
-                io = hdmf_zarr.NWBZarrIO(s3_url, mode="r")
-                nwbfile = io.read()
-            else:
-                rem_file = remfile.File(url=s3_url)
-                h5py_file = h5py.File(name=rem_file, mode="r")
-                io = pynwb.NWBHDF5IO(file=h5py_file)
-                nwbfile = io.read()
-
-            stage = "running the NWB Inspector"
-            inspector_messages = list(
-                nwbinspector.inspect_nwbfile_object(
-                    nwbfile_object=nwbfile,
-                    config=dandi_config,
-                    importance_threshold=nwbinspector.Importance.CRITICAL,
-                )
-            )
-            if inspector_messages:
-                joined_messages = "\n\n".join(str(inspector_message) for inspector_message in inspector_messages)
-                _log_error(
-                    log_file_path=nwb_inspector_errors_log_file_path,
-                    message=(
-                        f"NWB Inspector found CRITICAL issues for `{content_id=}` "
-                        f"(dandiset ID {dandiset_id}, path {first_path}, URL {s3_url})!\n\n"
-                        f"{joined_messages}"
-                    ),
-                )
-                error_ids.add(content_id)
-                continue
 
             stage = "validating SpikeInterface metadata"
             qualifies = _nwb_file_qualifies(s3_url=s3_url)

--- a/code/update_pipeline.sh
+++ b/code/update_pipeline.sh
@@ -39,6 +39,8 @@ BOT_NAME="github-actions[bot]"
 BOT_EMAIL="github-actions[bot]@users.noreply.github.com"
 SUBDATASET_PATH="sourcedata/content-id-to-usage-dandiset-path"
 SUBDATASET_URL="https://github.com/dandi-cache/content-id-to-usage-dandiset-path.git"
+VALID_NWB_SUBDATASET_PATH="sourcedata/content-id-to-valid-nwb-file"
+VALID_NWB_SUBDATASET_URL="https://github.com/dandi-cache/content-id-to-valid-nwb-file.git"
 DS="${RUNNER_TEMP:-/tmp}/derivatives-dataset"
 DISTDIR="${RUNNER_TEMP:-/tmp}/dist-publish"
 
@@ -61,6 +63,7 @@ else
   echo "Bootstrapping a new 'derivatives' DataLad dataset."
   datalad create --no-annex "${DS}"
   datalad clone -d "${DS}" "${SUBDATASET_URL}" "${DS}/${SUBDATASET_PATH}"
+  datalad clone -d "${DS}" "${VALID_NWB_SUBDATASET_URL}" "${DS}/${VALID_NWB_SUBDATASET_PATH}"
   datalad save -d "${DS}" -m "Initialize derivatives dataset"
 fi
 
@@ -73,14 +76,22 @@ mkdir -p "${DS}/derivatives" "${DS}/logs"
 cp "${WORKSPACE}/dataset_description.json" "${DS}/dataset_description.json"
 datalad save -d "${DS}" -m "Add BIDS study dataset_description.json" dataset_description.json || true
 
-# Advance the input subdataset to the tip of upstream's `derivatives` branch (where the
+# A persistent `derivatives` dataset created before this input was added won't have it
+# registered as a submodule yet; add it in that case rather than trying to update it.
+if ! git -C "${DS}" config -f .gitmodules --get "submodule.${VALID_NWB_SUBDATASET_PATH}.url" > /dev/null 2>&1; then
+  datalad clone -d "${DS}" "${VALID_NWB_SUBDATASET_URL}" "${DS}/${VALID_NWB_SUBDATASET_PATH}"
+fi
+
+# Advance the input subdatasets to the tip of upstream's `derivatives` branch (where the
 # input data is published) and record the pointer. The tracking branch is explicit, and the
 # submodule is only ever initialized with `--remote` so the previously recorded commit is
 # never fetched: upstream rewrites its history, so that commit may no longer exist on the
 # remote and fetching it fails with "not our ref".
 git -C "${DS}" submodule set-branch --branch derivatives -- "${SUBDATASET_PATH}"
 git -C "${DS}" submodule update --init --remote "${SUBDATASET_PATH}"
-datalad save -d "${DS}" -m "Update input subdataset to latest" "${SUBDATASET_PATH}" .gitmodules || true
+git -C "${DS}" submodule set-branch --branch derivatives -- "${VALID_NWB_SUBDATASET_PATH}"
+git -C "${DS}" submodule update --init --remote "${VALID_NWB_SUBDATASET_PATH}"
+datalad save -d "${DS}" -m "Update input subdatasets to latest" "${SUBDATASET_PATH}" "${VALID_NWB_SUBDATASET_PATH}" .gitmodules || true
 
 cd "${DS}"
 
@@ -101,6 +112,7 @@ datalad save -m "Pin runtime container image to ${DIGEST}" .datalad
 # prior state (input) and output of this run.
 datalad containers-run -n pipeline --explicit \
   --input "${SUBDATASET_PATH}" \
+  --input "${VALID_NWB_SUBDATASET_PATH}" \
   --output derivatives \
   --output logs \
   -m "Update qualifying AIND content IDs (code @ ${GITHUB_SHA}; image ${DIGEST})" \

--- a/envs/pyproject.toml
+++ b/envs/pyproject.toml
@@ -4,11 +4,6 @@ version = "0.1.0"
 requires-python = ">=3.13"
 dependencies = [
     "remfile",
-    "h5py",
-    "zarr",
-    "hdmf-zarr",
-    "pynwb",
-    "nwbinspector",
     "dandi",
     "spikeinterface",
     "datalad",


### PR DESCRIPTION
## Summary
This PR refactors the pipeline to trust an upstream cache for NWB file validation instead of performing file-open and NWB Inspector checks locally. This eliminates redundant validation work and simplifies the pipeline by removing dependencies on file I/O and inspection libraries.

## Key Changes
- **Removed local NWB validation**: Eliminated code that opened NWB files (HDF5 and Zarr formats) and ran NWB Inspector checks at the CRITICAL threshold
- **Added upstream cache integration**: Integrated the `content-id-to-valid-nwb-file` cache as a new input subdataset to determine which files are valid NWB files
- **Simplified content filtering**: Updated content ID filtering logic to rely on the upstream cache's validation results (`True`/`False`/absent) rather than performing local validation
- **Removed dependencies**: Removed imports and dependencies for `h5py`, `hdmf_zarr`, `pynwb`, `nwbinspector`, and `remfile` from the main pipeline code
- **Updated pipeline script**: Modified `update_pipeline.sh` to clone and maintain the new `content-id-to-valid-nwb-file` subdataset alongside the existing `content-id-to-usage-dandiset-path` subdataset
- **Updated documentation**: Clarified in README that NWB validity is determined by the upstream cache

## Implementation Details
- Content IDs marked as invalid (`False`) in the upstream cache are marked as processed without further work
- Content IDs not yet present in the upstream cache are deferred for future runs
- Only content IDs confirmed as valid (`True`) in the upstream cache proceed to SpikeInterface metadata validation
- The pipeline now has two input subdatasets that are both updated to the `derivatives` branch before processing
- Removed three dedicated error log files (`file_open_errors.txt`, `nwb_inspector_errors.txt`) as those validation stages no longer exist

https://claude.ai/code/session_0165VFPngEdpbXuN9zNX585M